### PR TITLE
controller: allow RBACSyncConfig to bind to ClusterRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,13 @@ For namespace-scoped `RBACSyncConfig`, the behavior is nearly identical except
 for the following:
 
 1. `RBACSyncConfig` must be defined with a namespace.
-2. `RBACSyncConfig` can only reference `Roles`.
-3. All `RoleBindings` created as a result of the `RBACSyncConfig` will be in
+2. All `RoleBindings` created as a result of the `RBACSyncConfig` will be in
    the same namespace.
+
+`RBACSyncConfig` may reference a `ClusterRole` to grant permissions to
+namespaced resources defined in the `ClusterRole` within the `RoleBinding`’s
+namespace. This allows administrators to define a set of common roles for the
+entire cluster, then reuse them within multiple namespaces.
 
 When deciding between using the two, you should mostly only need to look at
 whether your assigning `ClusterRoles` or `Roles` and then use the equivalent

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -337,10 +337,12 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 	active := map[string]struct{}{}
 
 	for _, binding := range config.Spec.Bindings {
-		// need to valdiate that we only create rolebindings with this configuration.
-		if binding.RoleRef.Kind != "Role" {
+		switch binding.RoleRef.Kind {
+		case "Role", "ClusterRole":
+			// valid role reference kind for the role binding.
+		default:
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
-				EventReasonBindingError, "RoleRef kind %q invalid for RBACSyncConfig on group %q, use only Role",
+				EventReasonBindingError, "RoleRef kind %q invalid for RBACSyncConfig on group %q, use only Role or ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
 			continue
 		}


### PR DESCRIPTION
Issue:
https://github.com/cruise-automation/rbacsync/issues/12

Context:
There are valid use cases for binding a namespaced user or group to a cluster
role. This change removes the validation that was preventing this. See the k8s
documentation on this.
https://kubernetes.io/docs/reference/access-authn-authz/rbac

Testing:
The previous test for binding invalid roles was modified to have a purely made up
role type name. A new test was added for testing binding a cluster role.