### PR TITLE
Do not modify group to role bindings when a temporary error occurs.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -345,14 +345,19 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			continue
 		}
 
+		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
+
 		members, err := gm.Members(binding.Group)
 		if err != nil {
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-			} else {
+			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
+				// An error occurred looking up the groups, it should be marked as active
+				// so the rolebindings are not deleted in the cleanup.
+				active[name] = struct{}{}
 			}
 
 			continue
@@ -365,7 +370,6 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			continue
 		}
 
-		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
 		if _, ok := active[name]; ok {
 			// we've already seen this as part of this loop, so we have a
 			// duplicate configuration. Since we key on config+group+role, the
@@ -503,15 +507,19 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 				binding.RoleRef.Kind, binding.Group)
 			continue
 		}
+		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
 
 		members, err := gm.Members(binding.Group)
 		if err != nil {
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-			} else {
+			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
+				// In the case of unknown memberships from the grouper, we want to keep what already exists
+				// so we mark the binding as active.
+				active[name] = struct{}{}
 			}
 
 			continue
@@ -524,7 +532,6 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			continue
 		}
 
-		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
 		if _, ok := active[name]; ok {
 			// we've already seen this as part of this loop, so we have a
 			// duplicate configuration. Since we key on config+group+role, the


### PR DESCRIPTION
When a temporary error causes a grouper to fail returning memberships for
a group the associated RoleBindings should not be modified.

This is a fix for issue #7 .