### PR TITLE
README: remove docker hub automated build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![RBACSync](project/images/logo-horizontal.png)
 
-[![Build Status](https://travis-ci.org/cruise-automation/rbacsync.svg?branch=master)](https://travis-ci.org/cruise-automation/rbacsync) [![Docker Automated Build](https://img.shields.io/docker/automated/cruise/rbacsync.svg?logo=docker)](https://hub.docker.com/r/cruise/rbacsync/)
+[![Build Status](https://travis-ci.org/cruise-automation/rbacsync.svg?branch=master)](https://travis-ci.org/cruise-automation/rbacsync)
 
 * [Usage](#usage)
   + [Custom Resources](#custom-resources)


### PR DESCRIPTION
The feature seems to be completely broken and is blocking the release. I'm going to have to hand build these and push them manually.

Signed-off-by: Stephen Day <stephen.day@getcruise.com>