### PR TITLE
add custom metrics for RBACSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ debugging.
 To use GSuite, you'll need a service account with "G Suite Domain-Wide
 Delegation of Authority". It's recommended to read the
 [guide](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
-to understand how this works in cause you run into issues. The blog
+to understand how this works in case you run into issues. The blog
 [Navigating the Google Suite Directory
 API](https://www.fin.com/post/2017/10/navigating-google-suite-directory-api)
 may also provide some insight.

--- a/example.yml
+++ b/example.yml
@@ -25,7 +25,7 @@ spec:
   - group: someother-group
     roleRef:
       apiGroup: rbac.authorization.k8s.io
-        kind: Role
+      kind: Role
       name: someother-role
 
   # Define group memberships directly

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -56,14 +56,6 @@ const (
 )
 
 const (
-	MetricsRBACSyncConfig        = "RBACSyncConfig"
-	MetricsClusterRBACSyncConfig = "ClusterRBACSyncConfig"
-
-	MetricsRoleBinding        = "RoleBinding"
-	MetricsClusterRoleBinding = "ClusterRoleBinding"
-)
-
-const (
 	EventReasonConfigEnqueued    = "ConfigEnqueued"
 	EventReasonBindingConfigured = "BindingConfigured"
 	EventReasonBindingDeleted    = "BindingDeleted"
@@ -289,10 +281,10 @@ func (c *Controller) enqueue(obj interface{}) {
 	switch obj.(type) {
 	case *rbacsyncv1alpha.RBACSyncConfig:
 		c.queue.AddRateLimited(key)
-		metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonConfigEnqueued).Inc()
+		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsRBACSyncConfig, EventReasonConfigEnqueued).Inc()
 	case *rbacsyncv1alpha.ClusterRBACSyncConfig:
 		c.clusterqueue.AddRateLimited(key)
-		metrics.RBACSyncConfigStatus.WithLabelValues(MetricsClusterRBACSyncConfig, EventReasonConfigEnqueued).Inc()
+		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsClusterRBACSyncConfig, EventReasonConfigEnqueued).Inc()
 	default:
 		klog.Warningf("ignoring object of type %T: %#v", obj, obj)
 		return // skip event emit below
@@ -357,7 +349,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for RBACSyncConfig on group %q, use only Role or ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -368,11 +360,11 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonUnknownGroup).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsRBACSyncConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
-				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsRBACSyncConfig, EventReasonBindingError).Inc()
 				// An error occurred looking up the groups, it should be marked as active
 				// so the rolebindings are not deleted in the cleanup.
 				active[name] = struct{}{}
@@ -385,7 +377,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingWarning, "%v/%v has no members for group %v",
 				config.Namespace, config.Name, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingWarning).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsRBACSyncConfig, EventReasonBindingWarning).Inc()
 			continue
 		}
 
@@ -396,7 +388,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
-			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingDuplicated).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -421,7 +413,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "unable to update or create RoleBinding %v/%v: %v",
 				rb.Namespace, rb.Name, err)
-			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingError).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -435,7 +427,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"RoleBinding %v/%v configured", created.Namespace, created.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingConfigured).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -470,7 +462,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 					EventReasonBindingError,
 					"RoleBinding %v/%v could not be deleted: %v",
 					rb.Namespace, rb.Name, err)
-				metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingError).Inc()
+				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -479,7 +471,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "RoleBinding %v/%v deleted", rb.Namespace, rb.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingDeleted).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil
@@ -528,7 +520,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for ClusterRBACSyncConfig on group %q, use only ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsClusterRBACSyncConfig, EventReasonBindingError).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsClusterRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
@@ -538,11 +530,11 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsClusterRBACSyncConfig, EventReasonUnknownGroup).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsClusterRBACSyncConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
-				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsClusterRBACSyncConfig, EventReasonBindingError).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsClusterRBACSyncConfig, EventReasonBindingError).Inc()
 				// In the case of unknown memberships from the grouper, we want to keep what already exists
 				// so we mark the binding as active.
 				active[name] = struct{}{}
@@ -555,7 +547,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingWarning, "%v has no members for group %v",
 				config.Name, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsClusterRBACSyncConfig, EventReasonBindingWarning).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.MetricsClusterRBACSyncConfig, EventReasonBindingWarning).Inc()
 			continue
 		}
 
@@ -566,7 +558,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
-			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingDuplicated).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsClusterRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -590,7 +582,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError,
 				"unable to update or create ClusterRoleBinding %v: %v", crb.Name, err)
-			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingError).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsClusterRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -604,7 +596,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"ClusterRoleBinding %v configured", created.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingConfigured).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsClusterRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -637,7 +629,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError,
 					"ClusterRoleBinding %v could not be deleted: %v", crb.Name, err)
-				metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingError).Inc()
+				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsClusterRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -646,7 +638,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "ClusterRoleBinding %v deleted", crb.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingDeleted).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.MetricsClusterRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"k8s.io/klog"
 	"time"
 
 	"github.com/pkg/errors"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	rbacsyncv1alpha "github.com/cruise-automation/rbacsync/pkg/apis/rbacsync/v1alpha"
 	clientset "github.com/cruise-automation/rbacsync/pkg/generated/clientset/versioned"
@@ -48,6 +48,7 @@ import (
 	informers "github.com/cruise-automation/rbacsync/pkg/generated/informers/externalversions/rbacsync/v1alpha"
 	listers "github.com/cruise-automation/rbacsync/pkg/generated/listers/rbacsync/v1alpha"
 	"github.com/cruise-automation/rbacsync/pkg/groups"
+	"github.com/cruise-automation/rbacsync/pkg/metrics"
 )
 
 const (
@@ -55,9 +56,18 @@ const (
 )
 
 const (
+	MetricsRBACSyncConfig        = "RBACSyncConfig"
+	MetricsRBACSyncClusterConfig = "RBACSyncClusterConfig"
+
+	MetricsRoleBinding        = "RoleBinding"
+	MetricsClusterRoleBinding = "ClusterRoleBinding"
+)
+
+const (
 	EventReasonConfigEnqueued    = "ConfigEnqueued"
 	EventReasonBindingConfigured = "BindingConfigured"
 	EventReasonBindingDeleted    = "BindingDeleted"
+	EventReasonBindingDuplicated = "BindingDuplicated"
 	EventReasonBindingError      = "BindingError"
 	EventReasonUnknownGroup      = "UnknownGroup"
 )
@@ -278,8 +288,10 @@ func (c *Controller) enqueue(obj interface{}) {
 	switch obj.(type) {
 	case *rbacsyncv1alpha.RBACSyncConfig:
 		c.queue.AddRateLimited(key)
+		metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonConfigEnqueued).Inc()
 	case *rbacsyncv1alpha.ClusterRBACSyncConfig:
 		c.clusterqueue.AddRateLimited(key)
+		metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncClusterConfig, EventReasonConfigEnqueued).Inc()
 	default:
 		klog.Warningf("ignoring object of type %T: %#v", obj, obj)
 		return // skip event emit below
@@ -344,6 +356,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for RBACSyncConfig on group %q, use only Role or ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
+			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -354,9 +367,11 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
+				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
+				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
 				// An error occurred looking up the groups, it should be marked as active
 				// so the rolebindings are not deleted in the cleanup.
 				active[name] = struct{}{}
@@ -369,6 +384,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "%v/%v has no members for group %v",
 				config.Namespace, config.Name, binding.Group)
+			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -378,7 +394,8 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			// result will be the same. Accordingly, we log the bad
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
-				EventReasonBindingError, "duplicate binding %v ignored", name)
+				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
+			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -403,6 +420,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "unable to update or create RoleBinding %v/%v: %v",
 				rb.Namespace, rb.Name, err)
+			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -416,7 +434,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"RoleBinding %v/%v configured", created.Namespace, created.Name)
-
+		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -451,6 +469,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 					EventReasonBindingError,
 					"RoleBinding %v/%v could not be deleted: %v",
 					rb.Namespace, rb.Name, err)
+				metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -459,6 +478,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "RoleBinding %v/%v deleted", rb.Namespace, rb.Name)
+		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil
@@ -507,6 +527,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for ClusterRBACSyncConfig on group %q, use only ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
+			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncClusterConfig, EventReasonBindingError).Inc()
 			continue
 		}
 		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
@@ -516,9 +537,11 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
+				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncClusterConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
+				metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncClusterConfig, EventReasonBindingError).Inc()
 				// In the case of unknown memberships from the grouper, we want to keep what already exists
 				// so we mark the binding as active.
 				active[name] = struct{}{}
@@ -531,6 +554,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "%v has no members for group %v",
 				config.Name, binding.Group)
+			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncClusterConfig, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -540,7 +564,8 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			// result will be the same. Accordingly, we log the bad
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
-				EventReasonBindingError, "duplicate binding %v ignored", name)
+				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
+			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -564,6 +589,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError,
 				"unable to update or create ClusterRoleBinding %v: %v", crb.Name, err)
+			metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -577,6 +603,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"ClusterRoleBinding %v configured", created.Name)
+		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -609,6 +636,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError,
 					"ClusterRoleBinding %v could not be deleted: %v", crb.Name, err)
+				metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -617,6 +645,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "ClusterRoleBinding %v deleted", crb.Name)
+		metrics.RBACSyncBindingStatus.WithLabelValues(MetricsClusterRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -281,10 +281,10 @@ func (c *Controller) enqueue(obj interface{}) {
 	switch obj.(type) {
 	case *rbacsyncv1alpha.RBACSyncConfig:
 		c.queue.AddRateLimited(key)
-		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.RBACSyncConfig, EventReasonConfigEnqueued).Inc()
+		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindRBACSyncConfig, EventReasonConfigEnqueued).Inc()
 	case *rbacsyncv1alpha.ClusterRBACSyncConfig:
 		c.clusterqueue.AddRateLimited(key)
-		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.ClusterRBACSyncConfig, EventReasonConfigEnqueued).Inc()
+		metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindClusterRBACSyncConfig, EventReasonConfigEnqueued).Inc()
 	default:
 		klog.Warningf("ignoring object of type %T: %#v", obj, obj)
 		return // skip event emit below
@@ -349,7 +349,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for RBACSyncConfig on group %q, use only Role or ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.RBACSyncConfig, EventReasonBindingError).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -360,11 +360,11 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.RBACSyncConfig, EventReasonUnknownGroup).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindRBACSyncConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
-				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.RBACSyncConfig, EventReasonBindingError).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindRBACSyncConfig, EventReasonBindingError).Inc()
 				// An error occurred looking up the groups, it should be marked as active
 				// so the rolebindings are not deleted in the cleanup.
 				active[name] = struct{}{}
@@ -377,7 +377,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingWarning, "%v/%v has no members for group %v",
 				config.Namespace, config.Name, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.RBACSyncConfig, EventReasonBindingWarning).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindRBACSyncConfig, EventReasonBindingWarning).Inc()
 			continue
 		}
 
@@ -388,7 +388,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
-			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.RoleBinding, EventReasonBindingDuplicated).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -413,7 +413,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "unable to update or create RoleBinding %v/%v: %v",
 				rb.Namespace, rb.Name, err)
-			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.RoleBinding, EventReasonBindingError).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -427,7 +427,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"RoleBinding %v/%v configured", created.Namespace, created.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.RoleBinding, EventReasonBindingConfigured).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -462,7 +462,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 					EventReasonBindingError,
 					"RoleBinding %v/%v could not be deleted: %v",
 					rb.Namespace, rb.Name, err)
-				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.RoleBinding, EventReasonBindingError).Inc()
+				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -471,7 +471,7 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "RoleBinding %v/%v deleted", rb.Namespace, rb.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.RoleBinding, EventReasonBindingDeleted).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil
@@ -520,7 +520,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError, "RoleRef kind %q invalid for ClusterRBACSyncConfig on group %q, use only ClusterRole",
 				binding.RoleRef.Kind, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.ClusterRBACSyncConfig, EventReasonBindingError).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindClusterRBACSyncConfig, EventReasonBindingError).Inc()
 			continue
 		}
 		name := config.Name + "-" + binding.Group + "-" + binding.RoleRef.Name
@@ -530,11 +530,11 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			if groups.IsNotFound(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonUnknownGroup, "group %v not found", binding.Group)
-				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.ClusterRBACSyncConfig, EventReasonUnknownGroup).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindClusterRBACSyncConfig, EventReasonUnknownGroup).Inc()
 			} else if groups.IsUnknownMemberships(err) {
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError, "group %v lookup failed: %v", binding.Group, err)
-				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.ClusterRBACSyncConfig, EventReasonBindingError).Inc()
+				metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindClusterRBACSyncConfig, EventReasonBindingError).Inc()
 				// In the case of unknown memberships from the grouper, we want to keep what already exists
 				// so we mark the binding as active.
 				active[name] = struct{}{}
@@ -547,7 +547,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingWarning, "%v has no members for group %v",
 				config.Name, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.ClusterRBACSyncConfig, EventReasonBindingWarning).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(metrics.LabelKindClusterRBACSyncConfig, EventReasonBindingWarning).Inc()
 			continue
 		}
 
@@ -558,7 +558,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			// configuration and move on.
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingDuplicated, "duplicate binding %v ignored", name)
-			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.ClusterRoleBinding, EventReasonBindingDuplicated).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindClusterRoleBinding, EventReasonBindingDuplicated).Inc()
 			continue
 		}
 
@@ -582,7 +582,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
 				EventReasonBindingError,
 				"unable to update or create ClusterRoleBinding %v: %v", crb.Name, err)
-			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.ClusterRoleBinding, EventReasonBindingError).Inc()
+			metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindClusterRoleBinding, EventReasonBindingError).Inc()
 			continue
 		}
 
@@ -596,7 +596,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingConfigured,
 			"ClusterRoleBinding %v configured", created.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.ClusterRoleBinding, EventReasonBindingConfigured).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindClusterRoleBinding, EventReasonBindingConfigured).Inc()
 	}
 
 	selector, err := buildChildSelector(config.Name)
@@ -629,7 +629,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 				c.recorder.Eventf(config, corev1.EventTypeWarning,
 					EventReasonBindingError,
 					"ClusterRoleBinding %v could not be deleted: %v", crb.Name, err)
-				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.ClusterRoleBinding, EventReasonBindingError).Inc()
+				metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindClusterRoleBinding, EventReasonBindingError).Inc()
 				continue
 			}
 
@@ -638,7 +638,7 @@ func (c *Controller) handleClusterConfig(config *rbacsyncv1alpha.ClusterRBACSync
 
 		c.recorder.Eventf(config, corev1.EventTypeNormal,
 			EventReasonBindingDeleted, "ClusterRoleBinding %v deleted", crb.Name)
-		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.ClusterRoleBinding, EventReasonBindingDeleted).Inc()
+		metrics.RBACSyncBindingStatus.WithLabelValues(metrics.LabelKindClusterRoleBinding, EventReasonBindingDeleted).Inc()
 	}
 
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -68,6 +68,7 @@ const (
 	EventReasonBindingConfigured = "BindingConfigured"
 	EventReasonBindingDeleted    = "BindingDeleted"
 	EventReasonBindingDuplicated = "BindingDuplicated"
+	EventReasonBindingWarning    = "BindingWarning"
 	EventReasonBindingError      = "BindingError"
 	EventReasonUnknownGroup      = "UnknownGroup"
 )
@@ -382,9 +383,9 @@ func (c *Controller) handleConfig(config *rbacsyncv1alpha.RBACSyncConfig) error 
 
 		if len(members) == 0 {
 			c.recorder.Eventf(config, corev1.EventTypeWarning,
-				EventReasonBindingError, "%v/%v has no members for group %v",
+				EventReasonBindingWarning, "%v/%v has no members for group %v",
 				config.Namespace, config.Name, binding.Group)
-			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingError).Inc()
+			metrics.RBACSyncConfigStatus.WithLabelValues(MetricsRBACSyncConfig, EventReasonBindingWarning).Inc()
 			continue
 		}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,10 +18,11 @@ package controller
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"k8s.io/klog"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	rbacsyncv1alpha "github.com/cruise-automation/rbacsync/pkg/apis/rbacsync/v1alpha"
 	"github.com/cruise-automation/rbacsync/pkg/checks"
@@ -116,7 +117,7 @@ func TestControllerRBACSyncConfig(t *testing.T) {
 				// the controller. It just creates the binding twice. We may
 				// change this to avoid extra round trip in these cases. We
 				// should probably actually warn.
-				"Warning BindingError duplicate binding duplicates-group0-role0 ignored",
+				"Warning BindingDuplicated duplicate binding duplicates-group0-role0 ignored",
 				"Normal BindingConfigured RoleBinding testing/duplicates-group0-role1 configured",
 				"Normal BindingConfigured RoleBinding testing/duplicates-upstream-role0 configured",
 			},
@@ -256,7 +257,7 @@ func TestControllerClusterRBACSyncConfig(t *testing.T) {
 				// the controller. It just creates the binding twice. We may
 				// change this to avoid extra round trip in these cases. We
 				// should probably actually warn.
-				"Warning BindingError duplicate binding duplicates-group0-role0 ignored",
+				"Warning BindingDuplicated duplicate binding duplicates-group0-role0 ignored",
 				"Normal BindingConfigured ClusterRoleBinding duplicates-group0-role1 configured",
 				"Normal BindingConfigured ClusterRoleBinding duplicates-upstream-role0 configured",
 			},

--- a/pkg/groups/gsuite/grouper.go
+++ b/pkg/groups/gsuite/grouper.go
@@ -111,11 +111,12 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 	ctx := context.TODO()
 	client, err := g.service(ctx)
 	if err != nil {
+		metrics.RBACSyncGsuiteClientCreationStatus.WithLabelValues("Failed").Inc()
 		return nil, errors.Wrapf(groups.ErrUnknown,
 			"unable to determine group members, an error occurred creating gsuite client: %v",
 			err)
 	}
-	metrics.RBACSyncGsuiteClientCreationStatus.Inc()
+	metrics.RBACSyncGsuiteClientCreationStatus.WithLabelValues("Succeeded").Inc()
 
 	var (
 		tctx, cancel = context.WithTimeout(ctx, g.timeout)

--- a/pkg/groups/gsuite/grouper.go
+++ b/pkg/groups/gsuite/grouper.go
@@ -139,24 +139,36 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 
 		switch {
 		case isNotFound(err):
+			metrics.RBACSyncGsuiteMembersLatency.WithLabelValues("NotFound").Observe(
+				float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
+			)
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("NotFound").Inc()
 			return nil, errors.Wrapf(groups.ErrNotFound, "gsuite does not have group: %v", err)
 		case isTimeout(tctx):
+			metrics.RBACSyncGsuiteMembersLatency.WithLabelValues("Timeout").Observe(
+				float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
+			)
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Timeout").Inc()
 			return nil, errors.Wrapf(groups.ErrTimeout, "timeout calling gsuite api: %v", err)
 		case isCanceled(tctx):
+			metrics.RBACSyncGsuiteMembersLatency.WithLabelValues("Canceled").Observe(
+				float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
+			)
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Canceled").Inc()
 			return nil, errors.Wrapf(groups.ErrCanceled, "the context canceled the call to gsuite: %v", err)
 		default:
+			metrics.RBACSyncGsuiteMembersLatency.WithLabelValues("Unknown").Observe(
+				float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
+			)
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Unknown").Inc()
 			return nil, errors.Wrapf(groups.ErrUnknown, "error retrieving group members: %v", err)
 		}
 
 	}
-	metrics.RBACSyncGsuiteMembersLatency.Observe(
+	metrics.RBACSyncGsuiteMembersLatency.WithLabelValues("Succeeded").Observe(
 		float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
 	)
-	metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("OK").Inc()
+	metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Succeeded").Inc()
 
 	// If you're trying to find some nasty memory allocation, it might be here.
 	// Grouper interface should be converted to callback style if this is a

--- a/pkg/groups/gsuite/grouper.go
+++ b/pkg/groups/gsuite/grouper.go
@@ -145,7 +145,7 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Timeout").Inc()
 			return nil, errors.Wrapf(groups.ErrTimeout, "timeout calling gsuite api: %v", err)
 		case isCanceled(tctx):
-			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Cancled").Inc()
+			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Canceled").Inc()
 			return nil, errors.Wrapf(groups.ErrCanceled, "the context canceled the call to gsuite: %v", err)
 		default:
 			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Unknown").Inc()

--- a/pkg/groups/gsuite/grouper.go
+++ b/pkg/groups/gsuite/grouper.go
@@ -23,13 +23,15 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/cruise-automation/rbacsync/pkg/groups"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/googleapi"
 	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/cruise-automation/rbacsync/pkg/groups"
+	"github.com/cruise-automation/rbacsync/pkg/metrics"
 )
 
 const (
@@ -110,9 +112,10 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 	client, err := g.service(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(groups.ErrUnknown,
-		"unable to determine group members, an error occurred creating gsuite client: %v",
-		err)
+			"unable to determine group members, an error occurred creating gsuite client: %v",
+			err)
 	}
+	metrics.RBACSyncGsuiteClientCreationStatus.Inc()
 
 	var (
 		tctx, cancel = context.WithTimeout(ctx, g.timeout)
@@ -120,6 +123,7 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 	)
 	defer cancel()
 
+	startTime := time.Now()
 	if err := client.Members.List(group).
 		IncludeDerivedMembership(true).
 		Pages(tctx, func(members *admin.Members) error {
@@ -135,16 +139,24 @@ func (g *Grouper) Members(group string) ([]rbacv1.Subject, error) {
 
 		switch {
 		case isNotFound(err):
+			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("NotFound").Inc()
 			return nil, errors.Wrapf(groups.ErrNotFound, "gsuite does not have group: %v", err)
 		case isTimeout(tctx):
+			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Timeout").Inc()
 			return nil, errors.Wrapf(groups.ErrTimeout, "timeout calling gsuite api: %v", err)
 		case isCanceled(tctx):
+			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Cancled").Inc()
 			return nil, errors.Wrapf(groups.ErrCanceled, "the context canceled the call to gsuite: %v", err)
 		default:
+			metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("Unknown").Inc()
 			return nil, errors.Wrapf(groups.ErrUnknown, "error retrieving group members: %v", err)
 		}
 
 	}
+	metrics.RBACSyncGsuiteMembersLatency.Observe(
+		float64(time.Since(startTime).Nanoseconds()) / float64(time.Second),
+	)
+	metrics.RBACSyncGsuiteMembersStatus.WithLabelValues("OK").Inc()
 
 	// If you're trying to find some nasty memory allocation, it might be here.
 	// Grouper interface should be converted to callback style if this is a

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,11 +6,11 @@ import (
 )
 
 const (
-	RBACSyncConfig        = "RBACSyncConfig"
-	ClusterRBACSyncConfig = "ClusterRBACSyncConfig"
+	LabelKindRBACSyncConfig        = "RBACSyncConfig"
+	LabelKindClusterRBACSyncConfig = "ClusterRBACSyncConfig"
 
-	RoleBinding        = "RoleBinding"
-	ClusterRoleBinding = "ClusterRoleBinding"
+	LabelKindRoleBinding        = "RoleBinding"
+	LabelKindClusterRoleBinding = "ClusterRoleBinding"
 )
 
 var (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,8 +33,8 @@ var (
 		Name: "rbacsync_gsuite_members_status",
 		Help: "Total number of the status of calls to gsuite with labels for state",
 	}, []string{"status"})
-	RBACSyncGsuiteMembersLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+	RBACSyncGsuiteMembersLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "rbacsync_gsuite_members_latency_duration_seconds",
 		Help: "The amount of time the calls to gsuite for group memberships",
-	})
+	}, []string{"status"})
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,7 +21,7 @@ var (
 	}, []string{"kind", "status"})
 	RBACSyncBindingStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "rbacsync_binding_status",
-		Help: "The number of RoleBindings and ClusterRoleBIndings configured by the controller and their statuses",
+		Help: "The number of RoleBindings and ClusterRoleBindings configured by the controller and their statuses",
 	}, []string{"kind", "status"})
 
 	// Metrics for Mapper/GSuite

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,11 +6,11 @@ import (
 )
 
 const (
-	MetricsRBACSyncConfig        = "RBACSyncConfig"
-	MetricsClusterRBACSyncConfig = "ClusterRBACSyncConfig"
+	RBACSyncConfig        = "RBACSyncConfig"
+	ClusterRBACSyncConfig = "ClusterRBACSyncConfig"
 
-	MetricsRoleBinding        = "RoleBinding"
-	MetricsClusterRoleBinding = "ClusterRoleBinding"
+	RoleBinding        = "RoleBinding"
+	ClusterRoleBinding = "ClusterRoleBinding"
 )
 
 var (
@@ -25,10 +25,10 @@ var (
 	}, []string{"kind", "status"})
 
 	// Metrics for Mapper/GSuite
-	RBACSyncGsuiteClientCreationStatus = promauto.NewCounter(prometheus.CounterOpts{
+	RBACSyncGsuiteClientCreationStatus = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "rbacsync_gsuite_client_creation_status",
 		Help: "Total number of the status of gsuite client creations",
-	})
+	}, []string{"status"})
 	RBACSyncGsuiteMembersStatus = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "rbacsync_gsuite_members_status",
 		Help: "Total number of the status of calls to gsuite with labels for state",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,6 +5,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	MetricsRBACSyncConfig        = "RBACSyncConfig"
+	MetricsClusterRBACSyncConfig = "ClusterRBACSyncConfig"
+
+	MetricsRoleBinding        = "RoleBinding"
+	MetricsClusterRoleBinding = "ClusterRoleBinding"
+)
+
 var (
 	// Metrics for Controller
 	RBACSyncConfigStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,7 +26,7 @@ var (
 		Help: "Total number of the status of calls to gsuite with labels for state",
 	}, []string{"status"})
 	RBACSyncGsuiteMembersLatency = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "rbacsync_gsuite_members_latency",
+		Name: "rbacsync_gsuite_members_latency_duration_seconds",
 		Help: "The amount of time the calls to gsuite for group memberships",
 	})
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Metrics for Controller
+	RBACSyncConfigStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rbacsync_config_status",
+		Help: "The number of RBACSyncConfigs and RBACSyncClusterConfigs and the status of the processed config",
+	}, []string{"kind", "status"})
+	RBACSyncBindingStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rbacsync_binding_status",
+		Help: "The number of RoleBindings and ClusterRoleBIndings configured by the controller and their statuses",
+	}, []string{"kind", "status"})
+
+	// Metrics for Mapper/GSuite
+	RBACSyncGsuiteClientCreationStatus = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "rbacsync_gsuite_client_creation_status",
+		Help: "Total number of the status of gsuite client creations",
+	})
+	RBACSyncGsuiteMembersStatus = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rbacsync_gsuite_members_status",
+		Help: "Total number of the status of calls to gsuite with labels for state",
+	}, []string{"status"})
+	RBACSyncGsuiteMembersLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "rbacsync_gsuite_members_latency",
+		Help: "The amount of time the calls to gsuite for group memberships",
+	})
+)

--- a/vendor/github.com/golang/protobuf/go.mod
+++ b/vendor/github.com/golang/protobuf/go.mod
@@ -1,0 +1,7 @@
+module github.com/golang/protobuf
+
+require (
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b
+)

--- a/vendor/github.com/google/go-cmp/go.mod
+++ b/vendor/github.com/google/go-cmp/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/go-cmp
+
+go 1.8

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/golang-lru

--- a/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
@@ -1,0 +1,223 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promauto provides constructors for the usual Prometheus metrics that
+// return them already registered with the global registry
+// (prometheus.DefaultRegisterer). This allows very compact code, avoiding any
+// references to the registry altogether, but all the constructors in this
+// package will panic if the registration fails.
+//
+// The following example is a complete program to create a histogram of normally
+// distributed random numbers from the math/rand package:
+//
+//      package main
+//
+//      import (
+//              "math/rand"
+//              "net/http"
+//
+//              "github.com/prometheus/client_golang/prometheus"
+//              "github.com/prometheus/client_golang/prometheus/promauto"
+//              "github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
+//              Name:    "random_numbers",
+//              Help:    "A histogram of normally distributed random numbers.",
+//              Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//      })
+//
+//      func Random() {
+//              for {
+//                      histogram.Observe(rand.NormFloat64())
+//              }
+//      }
+//
+//      func main() {
+//              go Random()
+//              http.Handle("/metrics", promhttp.Handler())
+//              http.ListenAndServe(":1971", nil)
+//      }
+//
+// Prometheus's version of a minimal hello-world program:
+//
+//      package main
+//
+//      import (
+//      	"fmt"
+//      	"net/http"
+//
+//      	"github.com/prometheus/client_golang/prometheus"
+//      	"github.com/prometheus/client_golang/prometheus/promauto"
+//      	"github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      func main() {
+//      	http.Handle("/", promhttp.InstrumentHandlerCounter(
+//      		promauto.NewCounterVec(
+//      			prometheus.CounterOpts{
+//      				Name: "hello_requests_total",
+//      				Help: "Total number of hello-world requests by HTTP code.",
+//      			},
+//      			[]string{"code"},
+//      		),
+//      		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//      			fmt.Fprint(w, "Hello, world!")
+//      		}),
+//      	))
+//      	http.Handle("/metrics", promhttp.Handler())
+//      	http.ListenAndServe(":1971", nil)
+//      }
+//
+// This appears very handy. So why are these constructors locked away in a
+// separate package? There are two caveats:
+//
+// First, in more complex programs, global state is often quite problematic.
+// That's the reason why the metrics constructors in the prometheus package do
+// not interact with the global prometheus.DefaultRegisterer on their own. You
+// are free to use the Register or MustRegister functions to register them with
+// the global prometheus.DefaultRegisterer, but you could as well choose a local
+// Registerer (usually created with prometheus.NewRegistry, but there are other
+// scenarios, e.g. testing).
+//
+// The second issue is that registration may fail, e.g. if a metric inconsistent
+// with the newly to be registered one is already registered. But how to signal
+// and handle a panic in the automatic registration with the default registry?
+// The only way is panicking. While panicking on invalid input provided by the
+// programmer is certainly fine, things are a bit more subtle in this case: You
+// might just add another package to the program, and that package (in its init
+// function) happens to register a metric with the same name as your code. Now,
+// all of a sudden, either your code or the code of the newly imported package
+// panics, depending on initialization order, without any opportunity to handle
+// the case gracefully. Even worse is a scenario where registration happens
+// later during the runtime (e.g. upon loading some kind of plugin), where the
+// panic could be triggered long after the code has been deployed to
+// production. A possibility to panic should be explicitly called out by the
+// Must… idiom, cf. prometheus.MustRegister. But adding a separate set of
+// constructors in the prometheus package called MustRegisterNewCounterVec or
+// similar would be quite unwieldy. Adding an extra MustRegister method to each
+// metric, returning the registered metric, would result in nice code for those
+// using the method, but would pollute every single metric interface for
+// everybody avoiding the global registry.
+//
+// To address both issues, the problematic auto-registering and possibly
+// panicking constructors are all in this package with a clear warning
+// ahead. And whoever cares about avoiding global state and possibly panicking
+// function calls can simply ignore the existence of the promauto package
+// altogether.
+//
+// A final note: There is a similar case in the net/http package of the standard
+// library. It has DefaultServeMux as a global instance of ServeMux, and the
+// Handle function acts on it, panicking if a handler for the same pattern has
+// already been registered. However, one might argue that the whole HTTP routing
+// is usually set up closely together in the same package or file, while
+// Prometheus metrics tend to be spread widely over the codebase, increasing the
+// chance of surprising registration failures. Furthermore, the use of global
+// state in net/http has been criticized widely, and some avoid it altogether.
+package promauto
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounter panics.
+func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	c := prometheus.NewCounter(opts)
+	prometheus.MustRegister(c)
+	return c
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterVec
+// panics.
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	c := prometheus.NewCounterVec(opts, labelNames)
+	prometheus.MustRegister(c)
+	return c
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterFunc
+// panics.
+func NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	g := prometheus.NewCounterFunc(opts, function)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGauge panics.
+func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	g := prometheus.NewGauge(opts)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeVec panics.
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeFunc panics.
+func NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	g := prometheus.NewGaugeFunc(opts, function)
+	prometheus.MustRegister(g)
+	return g
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummary panics.
+func NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	s := prometheus.NewSummary(opts)
+	prometheus.MustRegister(s)
+	return s
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummaryVec
+// panics.
+func NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	s := prometheus.NewSummaryVec(opts, labelNames)
+	prometheus.MustRegister(s)
+	return s
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogram panics.
+func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	h := prometheus.NewHistogram(opts)
+	prometheus.MustRegister(h)
+	return h
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogramVec
+// panics.
+func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	h := prometheus.NewHistogramVec(opts, labelNames)
+	prometheus.MustRegister(h)
+	return h
+}

--- a/vendor/google.golang.org/appengine/go.mod
+++ b/vendor/google.golang.org/appengine/go.mod
@@ -1,0 +1,7 @@
+module google.golang.org/appengine
+
+require (
+	github.com/golang/protobuf v1.2.0
+	golang.org/x/net v0.0.0-20180724234803-3673e40ba225
+	golang.org/x/text v0.3.0
+)

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/vendor/k8s.io/api/go.mod
+++ b/vendor/k8s.io/api/go.mod
@@ -1,0 +1,18 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/api
+
+go 1.12
+
+require (
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/stretchr/testify v1.2.2
+	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
+)
+
+replace (
+	golang.org/x/sync => golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20190209173611-3b5209105503
+	golang.org/x/tools => golang.org/x/tools v0.0.0-20190313210603-aa82965741a9
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
+)

--- a/vendor/k8s.io/apimachinery/go.mod
+++ b/vendor/k8s.io/apimachinery/go.mod
@@ -1,0 +1,43 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/apimachinery
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
+	github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e
+	github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903
+	github.com/golang/protobuf v1.2.0
+	github.com/google/go-cmp v0.3.0
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
+	github.com/google/uuid v1.0.0
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
+	github.com/hashicorp/golang-lru v0.5.0
+	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+	github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.1
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
+	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
+	gopkg.in/inf.v0 v0.9.0
+	gopkg.in/yaml.v2 v2.2.1
+	k8s.io/klog v0.3.1
+	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
+	sigs.k8s.io/yaml v1.1.0
+)
+
+replace (
+	golang.org/x/sync => golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20190209173611-3b5209105503
+	golang.org/x/tools => golang.org/x/tools v0.0.0-20190313210603-aa82965741a9
+)

--- a/vendor/k8s.io/client-go/go.mod
+++ b/vendor/k8s.io/client-go/go.mod
@@ -1,0 +1,42 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/client-go
+
+go 1.12
+
+require (
+	github.com/Azure/go-autorest v11.1.2+incompatible
+	github.com/davecgh/go-spew v1.1.1
+	github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda // indirect
+	github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903
+	github.com/golang/protobuf v1.2.0
+	github.com/google/btree v0.0.0-20160524151835-7d79101e329e // indirect
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
+	github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8
+	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7
+	github.com/imdario/mergo v0.3.5
+	github.com/peterbourgon/diskv v2.0.1+incompatible
+	github.com/spf13/pflag v1.0.1
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
+	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006
+	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	golang.org/x/time v0.0.0-20161028155119-f51c12702a4d
+	google.golang.org/appengine v1.5.0 // indirect
+	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
+	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
+	k8s.io/klog v0.3.1
+	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
+	sigs.k8s.io/yaml v1.1.0
+)
+
+replace (
+	golang.org/x/sync => golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20190209173611-3b5209105503
+	golang.org/x/tools => golang.org/x/tools v0.0.0-20190313210603-aa82965741a9
+	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
+)

--- a/vendor/k8s.io/kube-openapi/go.mod
+++ b/vendor/k8s.io/kube-openapi/go.mod
@@ -1,0 +1,37 @@
+module k8s.io/kube-openapi
+
+go 1.12
+
+require (
+	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
+	github.com/PuerkitoBio/purell v1.0.0 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2 // indirect
+	github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2
+	github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633
+	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680
+	github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1 // indirect
+	github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9 // indirect
+	github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501
+	github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87 // indirect
+	github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7
+	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367
+	github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9
+	github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3
+	github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da // indirect
+	github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
+	github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c
+	github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c
+	github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0 // indirect
+	github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff
+	github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365
+	golang.org/x/net v0.0.0-20170114055629-f2499483f923 // indirect
+	golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea // indirect
+	golang.org/x/text v0.0.0-20160726164857-2910a502d2bf // indirect
+	golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09 // indirect
+	gopkg.in/yaml.v2 v2.2.1
+	k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6
+	k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92
+	sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e
+)

--- a/vendor/k8s.io/utils/go.mod
+++ b/vendor/k8s.io/utils/go.mod
@@ -1,0 +1,10 @@
+module k8s.io/utils
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/spf13/afero v1.2.2
+	github.com/stretchr/testify v1.3.0
+	k8s.io/klog v0.3.0
+)


### PR DESCRIPTION
According to https://github.com/cruise-automation/rbacsync/issues/8, trying to add some metrics for `controller` and `gsuite/grouper` first and see how it goes


sample metrics exposed on `/metrics` endpoint
```
# HELP rbacsync_binding_status The number of RoleBindings and ClusterRoleBIndings configured by the controller and their statuses
# TYPE rbacsync_binding_status gauge
rbacsync_binding_status{kind="ClusterRoleBinding",status="BindingConfigured"} 14
rbacsync_binding_status{kind="RoleBinding",status="BindingConfigured"} 28
# HELP rbacsync_config_status The number of RBACSyncConfigs and RBACSyncClusterConfigs and the status of the processed config
# TYPE rbacsync_config_status gauge
rbacsync_config_status{kind="RBACSyncClusterConfig",status="BindingError"} 14
rbacsync_config_status{kind="RBACSyncClusterConfig",status="ConfigEnqueued"} 14
rbacsync_config_status{kind="RBACSyncClusterConfig",status="UnknownGroup"} 14
rbacsync_config_status{kind="RBACSyncConfig",status="ConfigEnqueued"} 14
rbacsync_config_status{kind="RBACSyncConfig",status="UnknownGroup"} 14
# HELP rbacsync_gsuite_client_creation_status Total number of the status of gsuite client creations
# TYPE rbacsync_gsuite_client_creation_status counter
rbacsync_gsuite_client_creation_status 0
# HELP rbacsync_gsuite_members_latency The amount of time the calls to gsuite for group memberships
# TYPE rbacsync_gsuite_members_latency histogram
rbacsync_gsuite_members_latency_bucket{le="0.005"} 0
rbacsync_gsuite_members_latency_bucket{le="0.01"} 0
rbacsync_gsuite_members_latency_bucket{le="0.025"} 0
rbacsync_gsuite_members_latency_bucket{le="0.05"} 0
rbacsync_gsuite_members_latency_bucket{le="0.1"} 0
rbacsync_gsuite_members_latency_bucket{le="0.25"} 0
rbacsync_gsuite_members_latency_bucket{le="0.5"} 0
rbacsync_gsuite_members_latency_bucket{le="1"} 0
rbacsync_gsuite_members_latency_bucket{le="2.5"} 0
rbacsync_gsuite_members_latency_bucket{le="5"} 0
rbacsync_gsuite_members_latency_bucket{le="10"} 0
rbacsync_gsuite_members_latency_bucket{le="+Inf"} 0
rbacsync_gsuite_members_latency_sum 0
rbacsync_gsuite_members_latency_count 0
```

Signed-off-by: Meng-Lin Lu <meng-lin.lu@getcruise.com>