### PR TITLE
Update CRDs to v1

### DIFF
--- a/deploy/00-crds.yml
+++ b/deploy/00-crds.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: rbacsyncconfigs.rbacsync.getcruise.com
@@ -11,10 +11,16 @@ spec:
     shortNames:
       - rsc
   scope: Namespaced
-  version: v1alpha
+  versions:
+    - name: v1alpha
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
   # TODO(sday): Create open API spec that validates all configs are RoleBindings
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterrbacsyncconfigs.rbacsync.getcruise.com
@@ -27,5 +33,11 @@ spec:
     shortNames:
       - crsc
   scope: Cluster
-  version: v1alpha
+  versions:
+    - name: v1alpha
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
   # TODO(sday): Create open API spec that validates all configs are ClusterRoleBindings


### PR DESCRIPTION
v1beta1 was dropped in 1.22 almost a year ago.
https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes